### PR TITLE
Updating login link to allow session resuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
         </p>
       </div>
       <div class="tablet:grid-col-8 usa-prose">
-        <a class="usa-button usa-button--secondary" href="https://idm.cms.gov/app/cms_snyk_1/exka3a609hoGZAcDy297/sso/saml" 
+        <a class="usa-button usa-button--secondary" href="https://idm.cms.gov/home/cms_snyk_1/0oaa3a609iWR3752w297/alna3acltlJmU1Be6297" 
           style='text-align: center; vertical-align: middle;'>
           <p>
           Click to Sign-in to Snyk.CMS.Gov


### PR DESCRIPTION
Previously our login link would force even users who have signed-in successfully to have to authenticate every time regardless if they already have an active IDM OKTA session. This PR aims to fix that. 